### PR TITLE
Refactored pipeline

### DIFF
--- a/DownloadMappings.py
+++ b/DownloadMappings.py
@@ -10,6 +10,11 @@ if os.path.isdir('map/vcf_ref/') is False:
 vcf_builds = ['GRCh37', 'GRCh38']
 vcf_chrs = list(range(1,23)) + ['X', 'Y', 'MT']
 
+for build in vcf_builds:
+    if os.path.isdir('map/vcf_ref/{}'.format(build)) is False:
+        os.mkdir('map/vcf_ref/{}'.format(build))
+        os.mkdir('map/vcf_ref/{}/cohort_ref'.format(build))
+
 # Download VCF files from ENSEMBL FTP
 ensembl_ftp = ftplib.FTP("ftp.ensembl.org")
 ensembl_ftp.login()

--- a/Harmonize.py
+++ b/Harmonize.py
@@ -321,9 +321,9 @@ def variant_HmVCF(v, vcfs_targetbuild, CohortVCF=None, returnOtherAllele=True):
             hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
 
     if hm_code is None:
-        if 'other_allele' in v:
+        if other_allele is not None:
             hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
-                                                 alleles=[v['effect_allele'], v['other_allele']])
+                                                 alleles=[v['effect_allele'], other_allele])
         else:
             hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
                                                  alleles=[v['effect_allele']])

--- a/Harmonize.py
+++ b/Harmonize.py
@@ -364,6 +364,8 @@ def run_HmVCF(args):
                                                                                    CohortVCF=usingCohortVCF,
                                                                                    returnOtherAllele=False)
     # Post-Harmonization Fixes
+    df_scoring.loc[df_scoring['hm_code'].isnull() == False, 'hm_code'] = [conv2int(x) for x in df_scoring.loc[
+                                                                          df_scoring['hm_code'].isnull() == False, 'hm_code']]
     if args.skip_strandflips is False:
         df_scoring = FixStrandFlips(df_scoring) # also returns new column 'hm_fixedStrandFlip'
 

--- a/Harmonize.py
+++ b/Harmonize.py
@@ -2,277 +2,362 @@ import argparse, os, sys, gzip
 from tqdm import tqdm
 from collections import Counter
 from pgs_harmonizer.harmonize import *
-from pgs_harmonizer.ensembl_tools import ensembl_post, clean_rsIDs, parse_var2location
-from pgs_harmonizer.liftover_tools import liftover, map_release
-from pgs_harmonizer.variantlookup_tools import VCFs
 
 # Inputs
 parser = argparse.ArgumentParser(
     description='Harmonize a PGS Catalog Scoring file (PGS######.txt.gz) to a specific genome build.')
-parser.add_argument("-id", dest="pgs_id", help="PGS Catalog Score ID", metavar="PGS######", required=True)
-parser.add_argument("-build", dest="target_build",
-                    help="Target genome build choices: 'GRCh37'or GRCh38'", metavar="GRCh3#",
-                    choices=['GRCh37', 'GRCh38'], required=True)
-parser.add_argument("-loc_scorefiles", dest="loc_scorefiles",
+subparsers = parser.add_subparsers(help='Harmonization Commands help', dest='HmAction',)
+
+# Sub-parser for HmPOS
+parser_POS = subparsers.add_parser('HmPOS', help='HmPOS - Harmonizing position information (adding/updating chr/pos information)')
+parser_POS.add_argument(dest="pgs_id", help="PGS Catalog Score ID", metavar="PGS######", type=str)
+parser_POS.add_argument(dest="target_build", help="Target genome build choices: 'GRCh37'or GRCh38'", metavar="GRCh3#",
+                    choices=['GRCh37', 'GRCh38'])
+parser_POS.add_argument("-loc_files", dest="loc_scorefiles",
                     help="Root directory where the PGS files are located, otherwise assumed to be in: ../pgs_ScoringFiles/",
                     metavar="DIR",
                     default='../pgs_ScoringFiles/', required=False)
-parser.add_argument("-source_build", dest="source_build",
+parser_POS.add_argument("-source_build", dest="source_build",
                     help="Source genome build [overwrites information in the scoring file header]",
                     metavar="GENOMEBUILD",
                     default=None, required=False)
-parser.add_argument("-cohort_vcf", dest="cohort_name",
+parser_POS.add_argument("-loc_hmoutput", dest="loc_outputs",
+                    help="Directory where the harmonization output will be saved (default: hm_coords/)",
+                    metavar="DIR",
+                    default='./hm_coords/', required=False)
+parser_POS.add_argument('--var2location',
+                    help='Uses the annotations from the var2location.pl script (ENSEMBL SQL connection)',
+                    action='store_true', required=False)
+parser_POS.add_argument('--silent_tqdm', help='Disables tqdm progress bar',
+                    action='store_true', required=False)
+parser_POS.add_argument('--ignore_rsid', help='Ignores rsID mappings and harmonizes variants using only liftover',
+                    action='store_true', required=False)
+parser_POS.add_argument('--gzip', help='Writes gzipped harmonized output',
+                    action='store_true', required=False)
+
+# Sub-parser for HmVCF
+parser_VCF = subparsers.add_parser('HmVCF', help='HmVCF - Checking positional information and/or adding other_alleles')
+parser_VCF.add_argument(dest="pgs_id", help="PGS Catalog Score ID", metavar="PGS######", type=str)
+parser_VCF.add_argument("-loc_files", dest="loc_scorefiles",
+                    help="Root directory where the PGS files are located, otherwise assumed to be in: ../pgs_ScoringFiles/",
+                    metavar="DIR",
+                    default='../pgs_ScoringFiles/', required=False)
+parser_VCF.add_argument("-cohort_vcf", dest="cohort_name",
                     help="Cohort VCF: Used to check if a variant is present in the genotyped/imputed variants for a "
                          "cohort and add other allele when the information from ENSEMBL is ambiguous "
                          "(multiple potential alleles)",
                     metavar="COHORT",
                     default=None, required=False)
-parser.add_argument("-loc_hmoutput", dest="loc_outputs",
-                    help="Directory where the harmonization output will be saved (default: hm_coords/)",
-                    metavar="DIR",
-                    default='./hm_coords/', required=False)
-parser.add_argument('--var2location',
-                    help='Uses the annotations from the var2location.pl script (ENSEMBL SQL connection)',
-                    action='store_true', required=False)
-parser.add_argument('--addOtherAllele',
+parser_VCF.add_argument('--addOtherAllele',
                     help='Adds a other_allele(s) column for PGS that only have a recorded effect_allele',
                     action='store_true', required=False)
-parser.add_argument('--addVariantID',
+parser_VCF.add_argument('--addVariantID',
                     help='Returns a column with the ID from the VCF corresponding to the match variant/allele(s)',
                     action='store_true', required=False)
-parser.add_argument('--ignore_rsid', help='Ignores rsID mappings and harmonizes variants using only liftover',
+parser_VCF.add_argument('--author_reported', help='Replaces unmappable variants (hm_code = -5) with the author-reported code (hm_code = 0)',
                     action='store_true', required=False)
-parser.add_argument('--author_reported', help='Replaces unmappable variants (hm_code = -5) with the author-reported code (hm_code = 0)',
-                    action='store_true', required=False)
-parser.add_argument('--skip_strandflips', help='This flag will stop the harmonizing from trying to correct strand flips',
+parser_VCF.add_argument('--skip_strandflips', help='This flag will stop the harmonizing from trying to correct strand flips',
                     action='store_false', required=False)
-parser.add_argument('--gzip', help='Writes gzipped harmonized output',
+parser_VCF.add_argument('--silent_tqdm', help='Disables tqdm progress bar',
                     action='store_true', required=False)
-parser.add_argument('--silent_tqdm', help='Disables tqdm progress bar',
+parser_VCF.add_argument('--gzip', help='Writes gzipped harmonized output',
                     action='store_true', required=False)
+
 args = parser.parse_args()
 
-## I/O File focations
-# Scoring file location
-if 'loc_scorefiles' in args:
-    if not args.loc_scorefiles.endswith('/'):
-        args.loc_scorefiles += '/'
-    loc_scorefile = args.loc_scorefiles + args.pgs_id + '.txt.gz'
-else:
-    loc_scorefile = '../pgs_ScoringFiles/{}.txt.gz'.format(args.pgs_id)
-# Define output location
-ofolder = args.loc_outputs
-if ofolder.endswith('/'):
-    ofolder = ofolder[:-1]
-if os.path.isdir(ofolder) is False:
-    os.mkdir(ofolder)
-if args.cohort_name is not None:
-    loc_hm_out = '{}/{}_{}hm{}.txt'.format(ofolder, args.pgs_id, args.cohort_name, args.target_build)
-else:
-    loc_hm_out = '{}/{}_hm{}.txt'.format(ofolder, args.pgs_id, args.target_build)
-if args.gzip is True:
-    loc_hm_out += '.gz'
 
-
-# Read Score File
-print('Reading Score File')
-header, df_scoring = read_scorefile(loc_scorefile)
-
-
-# Get consistent source build (e.g. NCBI/GRC)
-source_build = header['genome_build']
-source_build_mapped = None
-if args.source_build is not None:
-    source_build = args.source_build
-
-if source_build in map_release.values():
-    for grc, hg in map_release.items():
-        if hg == source_build:
-            source_build_mapped = grc
-    print('PGS ID: {} | Build: {}/{}'.format(header['pgs_id'], source_build, source_build_mapped))
-elif source_build in map_release.keys():
-    source_build_mapped = source_build
-    print('PGS ID: {} | Build: {}'.format(header['pgs_id'], source_build))
-else:
-    print('PGS ID: {} | Build: {}'.format(header['pgs_id'], source_build))
-print('Number of variants (score file lines) = {}'.format(header['variants_number']))
-# ToDo - print columns available for mapping
-
-# Sorting out the genome build
-mappable = False
-tf_unmappable2authorreported = False
-if source_build_mapped is None:
-    if 'rsID' in df_scoring.columns:
-        mappable = True
-    else:
-        sys.exit(
-            '{} CAN NOT BE HARMONIZED: Need to specify the source genome build (-source_build)'.format(header['pgs_id']))
-        # ToDo possibly implement a method to guess the genome build using GRCh37/38 VCFs
-else:
-    mappable = True
-
-if mappable is False:
-    sys.exit('{} CAN NOT BE HARMONIZED: Insufficient variant or genome build data for mapping'.format(header['pgs_id']))
-
-if args.target_build == source_build_mapped:
-    print('Harmonizing -> {}'.format(args.target_build))
-    if args.author_reported is True:
-        tf_unmappable2authorreported = True # This was implemented to handle INDELs with locations/allele notations that differ from the ENSEMBL VCF
-else:
-    print('Re-Mapping/Lifting + Harmonizing -> {}'.format(args.target_build))
-
-# Load Liftover Chains
-if source_build is not None:
-    build_map = liftover(source_build, args.target_build)  # Get the chain file
-else:
-    build_map = None
-
-# Source ENSEMBL DB/API variant mappings if required
-mapping_ensembl = None
-if 'rsID' in df_scoring.columns and args.ignore_rsid is False:
-    tomap_rsIDs = clean_rsIDs(list(df_scoring['rsID']))
-    if args.var2location:
-        # Write list of rsIDs that need mapping via ENSEMBL
-        with open('EnsemblMappings/variants/{}.txt'.format(header['pgs_id']), 'w') as outf:
-            outf.write('\n'.join(tomap_rsIDs))
-
-        # ToDo add command to run var2location.pl on the EBI cluster (using local ENSEMBL mirror) or loop through ENSEMBL VCF for mappings
-
-        # Load ENSEMBL mappings
-        loc_mapping = 'EnsemblMappings/{}/{}.out'.format(args.target_build, header['pgs_id'])
-        loc_mapping_UNION = 'EnsemblMappings/{}/UNION.out'.format(args.target_build)
-        if os.path.isfile(loc_mapping):
-            print('Retrieving rsID mappings from ENSEMBL Mirror (var2location.pl:{}.out)'.format(header['pgs_id']))
-            mapping_ensembl = parse_var2location(loc_mapping)
-        elif os.path.isfile(loc_mapping_UNION):
-            print('Retrieving rsID mappings from ENSEMBL Mirror (var2location.pl:UNION.out)')
-            mapping_ensembl = parse_var2location(loc_mapping_UNION, tomap_rsIDs)
-        else:
-            sys.exit('Error: No rsID mappings from ENSEMBL Mirror (var2location.pl)')
-    else:
-        print('Retrieving rsID mappings from ENSEMBL API')
-        mapping_ensembl = ensembl_post(tomap_rsIDs, args.target_build)  # Retrieve the SNP info from ENSEMBL
-
-# Load Variant References (VCF & Cohort)
-usingCohortVCF = False
-if args.cohort_name is not None:
-    vcfs_targetbuild = VCFs(build=args.target_build, cohort_name=args.cohort_name)
-    usingCohortVCF = True
-    args.addOtherAllele = True
-else:
-    vcfs_targetbuild = VCFs(build=args.target_build)  # ENSEMBL VCF
-
-print('Starting Mapping')
-mapped_counter = Counter()
-counter_hmcodes = Counter()
-
-# Create harmonization/output formatting objects
-if args.gzip is True:
-    hm_out = gzip.open(loc_hm_out, 'wt')
-else:
-    hm_out = open(loc_hm_out, 'w')
-
-# Check if extra columns (other_allele) will need to be added
-if (args.addOtherAllele is True) and (('other_allele' in df_scoring.columns) is False):
-    print('! Will INFER Reference/Other Allele')
-    df_scoring['other_allele'] = None
-hm_formatter = Harmonizer(df_scoring.columns, ensureOtherAllele=args.addOtherAllele, returnVariantID=args.addVariantID)
-hm_out.write('\t'.join(hm_formatter.cols_order) + '\n')
-
-#Loop through variants
-for i, v in tqdm(df_scoring.iterrows(), total=df_scoring.shape[0], disable=args.silent_tqdm):
-    v = dict(v)
-    # Variant harmonization information
-    current_rsID = None
-    hm_chr = None
-    hm_pos = None
-    hm_source = None  # {'Author-reported', 'ENSEMBL Variation', 'liftover' }
-    hm_alleles = []
-    hm_matchesVCF = False # T/F whether the variant is consistent with the VCF/Variant Lookup
-    hm_isPalindromic = False  # T/F whether the alleles are consistent with being palindromic
-    hm_isFlipped = False  # T/F whether the alleles are consistent with the negative strand (from VCF)
-    hm_liftover_multimaps = None  # T/F whether the position has a unique liftover patch; None if no liftover done
+def variant_HmPOS(v, rsIDmaps=None, liftchain=None, isSameBuild=False, inferOtherAllele=False):
+    hm_source = ''  # {'Author-reported', 'ENSEMBL Variation', 'liftover' }
+    hm_rsID = ''
+    hm_chr = ''
+    hm_pos = ''
     hm_inferOtherAllele = None  # Field to capture the inferred other/reference allele
-    hm_vid = None
-    hm_code = None  # Derived from the above True/False information
 
-    # Step 1) ADD/UPDATE CHROMOSOME POSITION
-    if mapping_ensembl and v['rsID'] in mapping_ensembl:
-        v_map = mapping_ensembl.get(v['rsID'])
+    if rsIDmaps and (v['rsID'] in rsIDmaps):
+        v_map = rsIDmaps.get(v['rsID'])
     else:
         v_map = None
 
     if v_map is not None:
         hm_chr, hm_pos, hm_alleles = list(v_map.select_canonical_data(chromosomes))
         hm_source = 'ENSEMBL'
-        current_rsID = v_map.id
-        if (args.addOtherAllele is True) and (pd.isnull(v.get('other_allele')) is True):
-            # Add other allele(s) based on ENSMEBL
-            hm_inferOtherAllele = v_map.infer_OtherAllele(v['effect_allele']) # Based on the rsID
-            v['other_allele'] = hm_inferOtherAllele
-        mapped_counter['mapped_rsID'] += 1
-    elif 'chr_name' and 'chr_position' in df_scoring.columns:
-        if source_build_mapped == args.target_build:
+        hm_rsID = v_map.id
+        if inferOtherAllele:
+            if 'other_allele' in v:
+                if pd.isnull(v.get('other_allele')) is True:
+                    hm_inferOtherAllele = v_map.infer_OtherAllele(v['effect_allele'])
+            else:
+                hm_inferOtherAllele = v_map.infer_OtherAllele(v['effect_allele'])  # Based on the rsID
+    elif 'chr_name' and 'chr_position' in v:
+        if isSameBuild:
             hm_chr = v['chr_name']
             hm_pos = v['chr_position']
             hm_source = 'Author-reported'  # Author-reported
-        elif (build_map is not None) and (build_map.chain is not None):
-            hm_chr, hm_pos, hm_liftover_multimaps = list(build_map.lift(v['chr_name'], v['chr_position']))  # liftover
-            hm_source = 'liftover'
-            mapped_counter['mapped_lift'] += 1
+        elif (liftchain is not None) and (liftchain.chain is not None):
+            if (pd.isnull(v['chr_name']) is False) and (pd.isnull(v['chr_position']) is False):
+                hm_chr, hm_pos, hm_liftover_multimaps = list(liftchain.lift(v['chr_name'], v['chr_position']))  # liftover
+                hm_source = 'liftover'
     if all([x is None for x in [hm_chr, hm_pos]]):
         hm_source = 'Unknown'
-        mapped_counter['mapped_unable'] += 1
 
-    # Step 2) CHECK VARIANT STATUS WITH RESPECT TO A VCF
-    if hm_source is not None:
-        v_records = vcfs_targetbuild.vcf_lookup(chromosome=hm_chr, position=hm_pos, rsid=current_rsID)
-        if usingCohortVCF:
-            hm_source += '+{}'.format(args.cohort_name)
+    if hm_pos != '':
+        hm_pos = str(hm_pos)
 
-        if 'other_allele' in v:
-            if (pd.isnull(v['other_allele']) is False) and ('/' in v['other_allele']) is False:
-                hm_TF, hm_vid = v_records.check_alleles(eff=v['effect_allele'],
-                                                        oa=v['other_allele'])
-                hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+    if inferOtherAllele:
+        if hm_inferOtherAllele is None:
+            hm_inferOtherAllele = ''
+        return pd.Series([hm_source, hm_rsID, hm_chr, hm_pos, hm_inferOtherAllele])
+    else:
+        return pd.Series([hm_source, hm_rsID, hm_chr, hm_pos])
+
+def run_HmPOS(args):
+    # Module-specifc imports
+    from pgs_harmonizer.ensembl_tools import ensembl_post, clean_rsIDs, parse_var2location
+    from pgs_harmonizer.liftover_tools import liftover, map_release
+
+    ## Set I/O File focations
+    # Scoring file location
+    if 'loc_scorefiles' in args:
+        if not args.loc_scorefiles.endswith('/'):
+            args.loc_scorefiles += '/'
+        loc_scorefile = args.loc_scorefiles + args.pgs_id + '.txt.gz'
+    else:
+        loc_scorefile = '../pgs_ScoringFiles/{}.txt.gz'.format(args.pgs_id)
+    # Define output location
+    ofolder = args.loc_outputs
+    if ofolder.endswith('/'):
+        ofolder = ofolder[:-1]
+    if os.path.isdir(ofolder) is False:
+        os.mkdir(ofolder)
+    loc_hm_out = '{}/{}_hmPOS{}.txt'.format(ofolder, args.pgs_id, args.target_build)
+    if args.gzip is True:
+        loc_hm_out += '.gz'
+
+    # Read Score File
+    print('Reading Score File')
+    header, df_scoring = read_scorefile(loc_scorefile)
+
+    # Get consistent source build (e.g. NCBI/GRC)
+    source_build = header['genome_build']
+    source_build_mapped = None
+    if args.source_build is not None:
+        source_build = args.source_build
+
+    if source_build in map_release.values():
+        for grc, hg in map_release.items():
+            if hg == source_build:
+                source_build_mapped = grc
+        print('PGS ID: {} | Build: {}/{}'.format(header['pgs_id'], source_build, source_build_mapped))
+    elif source_build in map_release.keys():
+        source_build_mapped = source_build
+        print('PGS ID: {} | Build: {}'.format(header['pgs_id'], source_build))
+    else:
+        print('PGS ID: {} | Build: {}'.format(header['pgs_id'], source_build))
+    print('Number of variants (score file lines) = {}'.format(header['variants_number']))
+    # ToDo - print columns available for mapping
+
+    # Sorting out the genome build
+    mappable = False
+    tf_unmappable2authorreported = False
+    if source_build_mapped is None:
+        if 'rsID' in df_scoring.columns:
+            mappable = True
+        else:
+            sys.exit(
+                '{} CAN NOT BE HARMONIZED: Need to specify the source genome build (-source_build)'.format(
+                    header['pgs_id']))
+            # ToDo possibly implement a method to guess the genome build using GRCh37/38 VCFs
+    else:
+        mappable = True
+
+    if mappable is False:
+        sys.exit(
+            '{} CAN NOT BE HARMONIZED: Insufficient variant or genome build data for mapping'.format(header['pgs_id']))
+
+    if args.target_build == source_build_mapped:
+        print('Harmonizing -> {}'.format(args.target_build))
+        isSameBuild = True
+    else:
+        print('Re-Mapping/Lifting + Harmonizing -> {}'.format(args.target_build))
+        isSameBuild = False
+
+    # Load Liftover Chains
+    if source_build is not None:
+        build_map = liftover(source_build, args.target_build)  # Get the chain file
+    else:
+        build_map = None
+
+    # Source ENSEMBL DB/API variant mappings if required
+    mapping_ensembl = None
+    if 'rsID' in df_scoring.columns and args.ignore_rsid is False:
+        tomap_rsIDs = clean_rsIDs(list(df_scoring['rsID']))
+        if args.var2location:
+            # Write list of rsIDs that need mapping via ENSEMBL
+            with open('EnsemblMappings/variants/{}.txt'.format(header['pgs_id']), 'w') as outf:
+                outf.write('\n'.join(tomap_rsIDs))
+
+            # ToDo add command to run var2location.pl on the EBI cluster (using local ENSEMBL mirror) or loop through ENSEMBL VCF for mappings
+
+            # Load ENSEMBL mappings
+            loc_mapping = 'EnsemblMappings/{}/{}.out'.format(args.target_build, header['pgs_id'])
+            loc_mapping_UNION = 'EnsemblMappings/{}/UNION.out'.format(args.target_build)
+            if os.path.isfile(loc_mapping):
+                print('Retrieving rsID mappings from ENSEMBL Mirror (var2location.pl:{}.out)'.format(header['pgs_id']))
+                mapping_ensembl = parse_var2location(loc_mapping)
+            elif os.path.isfile(loc_mapping_UNION):
+                print('Retrieving rsID mappings from ENSEMBL Mirror (var2location.pl:UNION.out)')
+                mapping_ensembl = parse_var2location(loc_mapping_UNION, tomap_rsIDs)
             else:
-                hm_inferOtherAllele, hm_TF, hm_vid, hm_code = v_records.infer_OtherAllele(eff=v['effect_allele'],
-                                                                                          oa_ensembl=hm_inferOtherAllele)
-                v['other_allele'] = hm_inferOtherAllele
-                hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+                sys.exit('Error: No rsID mappings from ENSEMBL Mirror (var2location.pl)')
         else:
-            hm_TF, hm_vid = v_records.check_alleles(eff=v['effect_allele'])
-            hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+            print('Retrieving rsID mappings from ENSEMBL API')
+            mapping_ensembl = ensembl_post(tomap_rsIDs, args.target_build)  # Retrieve the SNP info from ENSEMBL
+    # Run Variant Harmonization
+    tqdm.pandas()
+    df_scoring[['hm_source', 'hm_rsID', 'hm_chr', 'hm_pos', 'hm_inferOtherAllele']] = df_scoring.progress_apply(variant_HmPOS,
+                                                                                                                axis=1,
+                                                                                                                rsIDmaps=mapping_ensembl,
+                                                                                                                liftchain=build_map,
+                                                                                                                isSameBuild=isSameBuild,
+                                                                                                                inferOtherAllele=True)
+    df_scoring.to_csv(loc_hm_out, index = False, sep='\t') # Write output using pandas
 
-    if hm_code is None:
-        if 'other_allele' in v:
-            hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
-                                                 alleles=[v['effect_allele'], v['other_allele']])
-        else:
-            hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
-                                                 alleles=[v['effect_allele']])
-    hm = [hm_chr, hm_pos, hm_code]
 
-    # ToDo handle INDEL lookups in VCFs (e.g. ENSEMBL) better
-    # ToDo (use allele frequency to resolve ambiguous variants hm_code=3)
 
-    # Harmonize and write to file
-    v_hm = hm_formatter.format_line(v, hm, hm_source, source_build, rsid=current_rsID, vcfid=hm_vid,
-                                    fixflips=args.skip_strandflips,
-                                    unmappable2authorreported=tf_unmappable2authorreported)
-    counter_hmcodes[v_hm[-2]] += 1
-    hm_out.write('\t'.join(v_hm) + '\n')
+def run_HmVCF(args):
+    from pgs_harmonizer.variantlookup_tools import VCFs
 
-    # if (i % 250000 == 0) and (i != 0):
-    #     print('Mapped {} / {} lines'.format(i, df_scoring.shape[0]))
+    # Load Variant References (VCF & Cohort)
+    usingCohortVCF = False
+    if args.cohort_name is not None:
+        vcfs_targetbuild = VCFs(build=args.target_build, cohort_name=args.cohort_name)
+        usingCohortVCF = True
+        args.addOtherAllele = True
+    else:
+        vcfs_targetbuild = VCFs(build=args.target_build)  # ENSEMBL VCF
 
-hm_out.close()
+    return
 
-if mapped_counter['mapped_rsID'] > 0:
-    print('{} lines mapped by rsID'.format(mapped_counter['mapped_rsID']))
-if mapped_counter['mapped_lift'] > 0:
-    print('{} lines mapped by liftover'.format(mapped_counter['mapped_lift']))
-if mapped_counter['mapped_author'] > 0:
-    print('{} lines used author-reported mappings'.format(mapped_counter['mapped_author']))
-print(counter_hmcodes)
-print('Mapping complete')
+
+if __name__ == "__main__":
+    if args.HmAction == 'HmPOS':
+        run_HmPOS(args)
+    elif args.HmAction == 'HmVCF':
+        run_HmVCF(args)
+    else:
+        print('Not a valid method, try running: `python Harmonize.py -h` for valid options and more details')
+
+# print('Starting Mapping')
+# mapped_counter = Counter()
+# counter_hmcodes = Counter()
+#
+# # Create harmonization/output formatting objects
+# if args.gzip is True:
+#     hm_out = gzip.open(loc_hm_out, 'wt')
+# else:
+#     hm_out = open(loc_hm_out, 'w')
+#
+# # Check if extra columns (other_allele) will need to be added
+# if (args.addOtherAllele is True) and (('other_allele' in df_scoring.columns) is False):
+#     print('! Will INFER Reference/Other Allele')
+#     df_scoring['other_allele'] = None
+# hm_formatter = Harmonizer(df_scoring.columns, ensureOtherAllele=args.addOtherAllele, returnVariantID=args.addVariantID)
+# hm_out.write('\t'.join(hm_formatter.cols_order) + '\n')
+#
+# #Loop through variants
+# for i, v in tqdm(df_scoring.iterrows(), total=df_scoring.shape[0], disable=args.silent_tqdm):
+#     v = dict(v)
+#     # Variant harmonization information
+#     current_rsID = None
+#     hm_chr = None
+#     hm_pos = None
+#     hm_source = None  # {'Author-reported', 'ENSEMBL Variation', 'liftover' }
+#     hm_alleles = []
+#     hm_matchesVCF = False # T/F whether the variant is consistent with the VCF/Variant Lookup
+#     hm_isPalindromic = False  # T/F whether the alleles are consistent with being palindromic
+#     hm_isFlipped = False  # T/F whether the alleles are consistent with the negative strand (from VCF)
+#     hm_liftover_multimaps = None  # T/F whether the position has a unique liftover patch; None if no liftover done
+#     hm_inferOtherAllele = None  # Field to capture the inferred other/reference allele
+#     hm_vid = None
+#     hm_code = None  # Derived from the above True/False information
+#
+#     # Step 1) ADD/UPDATE CHROMOSOME POSITION
+#     if mapping_ensembl and v['rsID'] in mapping_ensembl:
+#         v_map = mapping_ensembl.get(v['rsID'])
+#     else:
+#         v_map = None
+#
+#     if v_map is not None:
+#         hm_chr, hm_pos, hm_alleles = list(v_map.select_canonical_data(chromosomes))
+#         hm_source = 'ENSEMBL'
+#         current_rsID = v_map.id
+#         if (args.addOtherAllele is True) and (pd.isnull(v.get('other_allele')) is True):
+#             # Add other allele(s) based on ENSMEBL
+#             hm_inferOtherAllele = v_map.infer_OtherAllele(v['effect_allele']) # Based on the rsID
+#             v['other_allele'] = hm_inferOtherAllele
+#         mapped_counter['mapped_rsID'] += 1
+#     elif 'chr_name' and 'chr_position' in df_scoring.columns:
+#         if source_build_mapped == args.target_build:
+#             hm_chr = v['chr_name']
+#             hm_pos = v['chr_position']
+#             hm_source = 'Author-reported'  # Author-reported
+#         elif (build_map is not None) and (build_map.chain is not None):
+#             hm_chr, hm_pos, hm_liftover_multimaps = list(build_map.lift(v['chr_name'], v['chr_position']))  # liftover
+#             hm_source = 'liftover'
+#             mapped_counter['mapped_lift'] += 1
+#     if all([x is None for x in [hm_chr, hm_pos]]):
+#         hm_source = 'Unknown'
+#         mapped_counter['mapped_unable'] += 1
+#
+#     # Step 2) CHECK VARIANT STATUS WITH RESPECT TO A VCF
+#     if hm_source is not None:
+#         v_records = vcfs_targetbuild.vcf_lookup(chromosome=hm_chr, position=hm_pos, rsid=current_rsID)
+#         if usingCohortVCF:
+#             hm_source += '+{}'.format(args.cohort_name)
+#
+#         if 'other_allele' in v:
+#             if (pd.isnull(v['other_allele']) is False) and ('/' in v['other_allele']) is False:
+#                 hm_TF, hm_vid = v_records.check_alleles(eff=v['effect_allele'],
+#                                                         oa=v['other_allele'])
+#                 hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+#             else:
+#                 hm_inferOtherAllele, hm_TF, hm_vid, hm_code = v_records.infer_OtherAllele(eff=v['effect_allele'],
+#                                                                                           oa_ensembl=hm_inferOtherAllele)
+#                 v['other_allele'] = hm_inferOtherAllele
+#                 hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+#         else:
+#             hm_TF, hm_vid = v_records.check_alleles(eff=v['effect_allele'])
+#             hm_matchesVCF, hm_isPalindromic, hm_isFlipped = hm_TF
+#
+#     if hm_code is None:
+#         if 'other_allele' in v:
+#             hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
+#                                                  alleles=[v['effect_allele'], v['other_allele']])
+#         else:
+#             hm_code = DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,
+#                                                  alleles=[v['effect_allele']])
+#     hm = [hm_chr, hm_pos, hm_code]
+#
+#     # ToDo handle INDEL lookups in VCFs (e.g. ENSEMBL) better
+#     # ToDo (use allele frequency to resolve ambiguous variants hm_code=3)
+#
+#     # Harmonize and write to file
+#     v_hm = hm_formatter.format_line(v, hm, hm_source, source_build, rsid=current_rsID, vcfid=hm_vid,
+#                                     fixflips=args.skip_strandflips,
+#                                     unmappable2authorreported=tf_unmappable2authorreported)
+#     counter_hmcodes[v_hm[-2]] += 1
+#     hm_out.write('\t'.join(v_hm) + '\n')
+#
+#     # if (i % 250000 == 0) and (i != 0):
+#     #     print('Mapped {} / {} lines'.format(i, df_scoring.shape[0]))
+#
+# hm_out.close()
+#
+# if mapped_counter['mapped_rsID'] > 0:
+#     print('{} lines mapped by rsID'.format(mapped_counter['mapped_rsID']))
+# if mapped_counter['mapped_lift'] > 0:
+#     print('{} lines mapped by liftover'.format(mapped_counter['mapped_lift']))
+# if mapped_counter['mapped_author'] > 0:
+#     print('{} lines used author-reported mappings'.format(mapped_counter['mapped_author']))
+# print(counter_hmcodes)
+# print('Mapping complete')

--- a/Harmonize.py
+++ b/Harmonize.py
@@ -403,8 +403,12 @@ def run_HmVCF(args):
     hm_Passed = True
     while hm_Passed is True:
         try:
+            df_scoring['hm_chr'].fillna('', inplace=True)
             for hm_chr, df_chrom in df_scoring.groupby('hm_chr'):
-                print('Harmonizing Chromosome: {}'.format(hm_chr))
+                if hm_chr is '':
+                    print('Harmonizing Chromosome: No HM_CHR')
+                else:
+                    print('Harmonizing Chromosome: {}'.format(hm_chr))
                 df_chrom = df_chrom.copy()
                 if args.addOtherAllele is True:
                     df_chrom[['hm_source', 'hm_vid', 'hm_code', 'other_allele']] = df_chrom.progress_apply(variant_HmVCF,
@@ -441,7 +445,7 @@ def run_HmVCF(args):
                 else:
                     df_chrom.to_csv(hm_out, mode='a', index=False, header=False, sep='\t')  # Write output using pandas
                 chrcount += 1
-            hm_Passed =  'COMPLETED'
+            hm_Passed = 'COMPLETED'
         except:
             hm_Passed = False
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,52 @@ variant batches using the Ensembl API. There are ways to speed this up by lookin
 - VCFs from Ensembl (in `/map/vcf_ref/`) or a specific cohort (in `/map/cohort_ref/`). Ensembl VCFs can be downloaded 
 by running the `DownloadMappings.py` script in the project directory.
 
+## Current options
+<pre>$ python ./Harmonize.py -h
+usage: Harmonize.py [-h] {HmPOS,HmVCF} ...
+
+Harmonize a PGS Catalog Scoring file (PGS######.txt.gz) to a specific genome
+build.
+
+positional arguments:
+  {HmPOS,HmVCF}  Harmonization Commands help
+    HmPOS        HmPOS - Harmonizing position information (adding/updating
+                 chr/pos information)
+    HmVCF        HmVCF - Checking positional information and/or adding
+                 other_alleles
+
+optional arguments:
+  -h, --help     show this help message and exit</pre>
+  
+<pre>python Harmonize.py HmPOS -h
+usage: Harmonize.py HmPOS [-h] [-loc_files DIR] [-source_build GENOMEBUILD]
+                          [-loc_hmoutput DIR] [--var2location] [--silent_tqdm]
+                          [--ignore_rsid] [--gzip]
+                          PGS###### GRCh3#
+
+positional arguments:
+  PGS######             PGS Catalog Score ID
+  GRCh3#                Target genome build choices: 'GRCh37'or GRCh38'
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -loc_files DIR        Root directory where the PGS files are located,
+                        otherwise assumed to be in: ../pgs_ScoringFiles/
+  -source_build GENOMEBUILD
+                        Source genome build [overwrites information in the
+                        scoring file header]
+  -loc_hmoutput DIR     Directory where the harmonization output will be saved
+                        (default: hm_coords/)
+  --var2location        Uses the annotations from the var2location.pl script
+                        (ENSEMBL SQL connection)
+  --silent_tqdm         Disables tqdm progress bar
+  --ignore_rsid         Ignores rsID mappings and harmonizes variants using
+                        only liftover
+  --gzip                Writes gzipped harmonized output
+(pgs-harmonizer) cmpc373:pgs-harmonizer sl925$ 
+</pre>
+
+## _OUTDATED:_ Examples
 To test that the pipeline can run try these commands on the test data in the project directory:
     
     # GRCh37
@@ -20,44 +66,6 @@ To test that the pipeline can run try these commands on the test data in the pro
     # GRCh38
     python Harmonize.py -id PGS000015 -loc_scorefiles test_data/ -build GRCh38 -loc_hmoutput test_data/
     python Harmonize.py -id PGS000065 -loc_scorefiles test_data/ -build GRCh38 -loc_hmoutput test_data/
-## Current options
-<pre>$ python ./Harmonize.py -h
-usage: Harmonize.py [-h] -id PGS###### -build GRCh## [-loc_scorefiles DIR]
-                    [-source_build GENOMEBUILD] [-cohort_vcf COHORT]
-                    [--var2location] [--addOtherAllele] [--ignore_rsid]
-                    [--gzip]
-
-Harmonize a PGS Catalog Scoring file (PGS######.txt.gz) to a specific genome
-build.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -id PGS######         PGS Catalog Score ID
-  -build GRCh##         Target genome build choices: 'GRCh37'or GRCh38'
-  -loc_scorefiles DIR   Root directory where the PGS files are located,
-                        otherwise assumed to be in: ../pgs_ScoringFiles/
-  -source_build GENOMEBUILD
-                        Source genome build [overwrites information in the
-                        scoring file header]
-  -cohort_vcf COHORT    Cohort VCF: Used to check if a variant is present in
-                        the genotyped/imputed variants for a cohort and add
-                        other allele when the information from ENSEMBL is
-                        ambiguous (multiple potential alleles)
-  -loc_hmoutput DIR     Directory where the harmonization output will be saved
-                        (default: hm_coords/)
-  --var2location        Uses the annotations from the var2location.pl script
-                        (ENSEMBL SQL connection)
-  --addOtherAllele      Adds a other_allele(s) column for PGS that only have a
-                        recorded effect_allele
-  --addVariantID        Returns a column with the ID from the VCF
-                        corresponding to the match variant/allele(s)
-  --ignore_rsid         Ignores rsID mappings and harmonizes variants using
-                        only liftover
-  --author_reported     Replaces unmappable variants (hm_code = -5) with the
-                        author-reported code (hm_code = 0)                       
-  --skip_strandflips    This flag will stop the harmonizing from trying to
-                        correct strand flips
-  --gzip                Writes gzipped harmonized output</pre>
 
 ## pseudocode (adapted from GWAS Catalog [README](https://github.com/EBISPOT/sum-stats-formatter/blob/master/harmonisation/README.md))
 <pre>READ/PARSE PGS Scoring File and headers

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ positional arguments:
 optional arguments:
   -h, --help     show this help message and exit</pre>
   
-<pre>python Harmonize.py HmPOS -h
+<pre>$ python ./Harmonize.py HmPOS -h
 usage: Harmonize.py HmPOS [-h] [-loc_files DIR] [-source_build GENOMEBUILD]
                           [-loc_hmoutput DIR] [--var2location] [--silent_tqdm]
                           [--ignore_rsid] [--gzip]
@@ -47,30 +47,70 @@ optional arguments:
                         Source genome build [overwrites information in the
                         scoring file header]
   -loc_hmoutput DIR     Directory where the harmonization output will be saved
-                        (default: hm_coords/)
+                        (default: PGS_HmPOS/)
   --var2location        Uses the annotations from the var2location.pl script
                         (ENSEMBL SQL connection)
   --silent_tqdm         Disables tqdm progress bar
   --ignore_rsid         Ignores rsID mappings and harmonizes variants using
                         only liftover
-  --gzip                Writes gzipped harmonized output
-(pgs-harmonizer) cmpc373:pgs-harmonizer sl925$ 
+  --gzip                Writes gzipped harmonized output</pre>
+
+<pre>$ python ./Harmonize.py HmVCF -h
+usage: Harmonize.py HmVCF [-h] [-loc_files DIR] [-loc_hmoutput DIR]
+                          [-cohort_vcf COHORT] [--addOtherAllele]
+                          [--addVariantID] [--author_reported]
+                          [--skip_strandflips] [--silent_tqdm] [--gzip]
+                          PGS###### GRCh3#
+
+positional arguments:
+  PGS######           PGS Catalog Score ID
+  GRCh3#              Target genome build choices: 'GRCh37'or GRCh38'
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -loc_files DIR      Root directory where the PGS files are located,
+                      otherwise assumed to be in: PGS_HmPOS/
+  -loc_hmoutput DIR   Directory where the harmonization output will be saved
+                      (default: PGS_HmPOS/)
+  -cohort_vcf COHORT  Cohort VCF: Used to check if a variant is present in the
+                      genotyped/imputed variants for a cohort and add other
+                      allele when the information from ENSEMBL is ambiguous
+                      (multiple potential alleles)
+  --addOtherAllele    Adds a other_allele(s) column for PGS that only have a
+                      recorded effect_allele
+  --addVariantID      Returns a column with the ID from the VCF corresponding
+                      to the match variant/allele(s)
+  --author_reported   Replaces unmappable variants (hm_code = -5) with the
+                      author-reported code (hm_code = 0)
+  --skip_strandflips  This flag will stop the harmonizing from trying to
+                      correct strand flips
+  --silent_tqdm       Disables tqdm progress bar
+  --gzip              Writes gzipped harmonized output
 </pre>
 
-## _OUTDATED:_ Examples
+## Examples
 To test that the pipeline can run try these commands on the test data in the project directory:
     
-    # GRCh37
-    python Harmonize.py -id PGS000015 -loc_scorefiles test_data/ -build GRCh37 -loc_hmoutput test_data/
-    python Harmonize.py -id PGS000065 -loc_scorefiles test_data/ -build GRCh37 -loc_hmoutput test_data/
-    # GRCh38
-    python Harmonize.py -id PGS000015 -loc_scorefiles test_data/ -build GRCh38 -loc_hmoutput test_data/
-    python Harmonize.py -id PGS000065 -loc_scorefiles test_data/ -build GRCh38 -loc_hmoutput test_data/
-
+    # PGS000015
+    ## GRCh37
+    python Harmonize.py HmPOS PGS000015 GRCh37 -loc_files ./test_data/ --gzip
+    python Harmonize.py HmVCF PGS000015 GRCh37 --gzip
+    ## GRCh38
+    python Harmonize.py HmPOS PGS000015 GRCh38 -loc_files ./test_data/ --gzip
+    python Harmonize.py HmVCF PGS000015 GRCh38 --gzip
+    
+    # PGS000065
+    ## GRCh37
+    python Harmonize.py HmPOS PGS000065 GRCh37 -loc_files ./test_data/ --gzip
+    python Harmonize.py HmVCF PGS000065 GRCh37 --gzip
+    ## GRCh38
+    python Harmonize.py HmPOS PGS000065 GRCh38 -loc_files ./test_data/ --gzip
+    python Harmonize.py HmVCF PGS000065 GRCh38 --gzip
+   
 ## pseudocode (adapted from GWAS Catalog [README](https://github.com/EBISPOT/sum-stats-formatter/blob/master/harmonisation/README.md))
 <pre>READ/PARSE PGS Scoring File and headers
 
-FOR each variant in file
+FOR each variant
     IF RSID maps to genomic location in Ensembl THEN
         update locations based on Ensembl mapping
         IF RSID != original RSID THEN

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -24,17 +24,20 @@ remap_header = {
 chromosomes = [str(x) for x in range(1,23)] + ['X', 'Y', 'MT']
 acceptable_alleles = re.compile('[ACGT]*$')  # alleles that can be reverse complemented
 
+
 def reversecomplement(x):
     if acceptable_alleles.match(x):
         return ''.join([{'A':'T','C':'G','G':'C','T':'A'}[B] for B in x][::-1])
     else:
         return None
 
+
 def conv2int(n):
     try:
         return int(n)
     except:
         return n
+
 
 def read_scorefile(loc_scorefile):
     """Loads PGS Catalog Scoring file and parses the header into a dictionary"""

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -182,7 +182,7 @@ class Harmonizer:
         Outputs any changes to an hm_info dictionary"""
         # Initialize Output
         l_output = ['']*len(self.cols_order)
-        hm_info = {}
+        hm_info = {'hm_source': v['hm_source']}
 
         # Decide how to output the variant (pass/fail harmonization)
         PassHM = True

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -236,19 +236,21 @@ class Harmonizer:
                 hm_info['hm_chr'] = v['hm_chr']
             if pd.isnull(v['hm_pos']) is False:
                 hm_info['hm_pos'] = v['hm_pos']
-            rsid = v['hm_rsID']
-            if pd.isnull(rsid) is False:  # mapped by rsID
-                hm_info['rsID'] = rsid
-                if rsid != v['rsID']:
-                    hm_info['previous_rsID'] = v['rsID']
-            else:
-                hm_info['rsID'] = v['rsID']
 
             for colname in self.hm_fields:
                 if colname in v:
-                    val = v[colname]
-                    if pd.isnull(val) is False:
-                        hm_info[colname] = val
+                    if colname is 'rsID':
+                        rsid = v['hm_rsID']
+                        if pd.isnull(rsid) is False:  # mapped by rsID
+                            hm_info['rsID'] = rsid
+                            if rsid != v['rsID']:
+                                hm_info['previous_rsID'] = v['rsID']
+                        else:
+                            hm_info['rsID'] = v['rsID']
+                    else:
+                        val = v[colname]
+                        if pd.isnull(val) is False:
+                            hm_info[colname] = val
 
             for i, colname in enumerate(self.cols_order):
                 if colname not in self.hm_fields:

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -203,7 +203,7 @@ class Harmonizer:
                         hm_info['fixedStrandFlip'] = False
 
         # Create Output
-        l_output[self.cols_order.index('hm_code')] = hm_code
+
 
         if original_build is None:
             original_build = 'NR'
@@ -224,7 +224,7 @@ class Harmonizer:
                 elif colname == 'variant_id':
                     l_output[i] = v['hm_vid']
                 elif colname == 'hm_code':
-                    l_output[i] = hm_code
+                    l_output[i] = str(hm_code)
                 elif colname == 'hm_info':
                     if len(hm_info) > 0:
                         l_output[i] = json.dumps(hm_info)
@@ -256,6 +256,8 @@ class Harmonizer:
                         hm_info['variant_id'] = v['hm_vid']
                     elif colname == 'hm_info':
                         l_output[i] = json.dumps(hm_info)
+                    elif colname == 'hm_code':
+                        l_output[i] = str(hm_code)
                     else:
                         l_output[i] = v[colname]
 

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -38,8 +38,10 @@ def read_scorefile(loc_scorefile):
         f = open(loc_scorefile, 'rt')
 
     header = {}
-    for line in f:
-        line = line.strip()
+    lastline = '#'
+    while lastline.startswith('#'):
+        lastline = f.readline()
+        line = lastline.strip()
         if line.startswith('#'):
             if '=' in line:
                 line = line[1:].split('=')
@@ -47,7 +49,7 @@ def read_scorefile(loc_scorefile):
                 header[remap_header[field]] = val # ToDo change once Scoring File headers are fixed
     f.close()
 
-    if header['genome_build'] == 'NR':
+    if ('genome_build' in header) and (header['genome_build'] == 'NR'):
         header['genome_build'] = None
 
     df_scoring = pd.read_table(loc_scorefile, float_precision='round_trip', comment='#',
@@ -57,10 +59,16 @@ def read_scorefile(loc_scorefile):
     # Make sure certain columns maintain specific datatypes
     if 'reference_allele' in df_scoring.columns:
         df_scoring = df_scoring.rename(columns={"reference_allele": "other_allele"})
+
     if 'chr_name' in df_scoring.columns:
         df_scoring['chr_name'] = df_scoring['chr_name'].astype('str') # Asssert character in case there are only chr numbers
+    if 'hm_chr' in df_scoring.columns:
+        df_scoring['hm_chr'] = df_scoring['hm_chr'].astype('str') # Asssert character in case there are only chr numbers
+
     if 'chr_position' in df_scoring.columns:
         df_scoring.loc[df_scoring['chr_position'].isnull() == False, 'chr_position'] = [conv2int(x) for x in df_scoring.loc[df_scoring['chr_position'].isnull() == False, 'chr_position']]
+    if 'hm_pos' in df_scoring.columns:
+        df_scoring.loc[df_scoring['hm_pos'].isnull() == False, 'hm_pos'] = [conv2int(x) for x in df_scoring.loc[df_scoring['hm_pos'].isnull() == False, 'hm_pos']]
 
     return(header, df_scoring)
 

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -60,19 +60,17 @@ def read_scorefile(loc_scorefile):
 
     df_scoring = pd.read_table(loc_scorefile, float_precision='round_trip', comment='#',
                                dtype = {'chr_position' : 'object',
-                                        'chr_name' : 'object'})
+                                        'chr_name' : 'object',
+                                        'hm_chr': 'object',
+                                        'hm_pos': 'object'})
 
     # Make sure certain columns maintain specific datatypes
     if 'reference_allele' in df_scoring.columns:
         df_scoring = df_scoring.rename(columns={"reference_allele": "other_allele"})
 
-    if 'hm_chr' in df_scoring.columns:
-        df_scoring['hm_chr'] = df_scoring['hm_chr'].astype('str') # Asssert character in case there are only chr numbers
-
-    if 'chr_position' in df_scoring.columns:
-        df_scoring.loc[df_scoring['chr_position'].isnull() == False, 'chr_position'] = [conv2int(x) for x in df_scoring.loc[df_scoring['chr_position'].isnull() == False, 'chr_position']]
-    if 'hm_pos' in df_scoring.columns:
-        df_scoring.loc[df_scoring['hm_pos'].isnull() == False, 'hm_pos'] = [conv2int(x) for x in df_scoring.loc[df_scoring['hm_pos'].isnull() == False, 'hm_pos']]
+    for poscol in ['chr_position', 'hm_pos']:
+        if poscol in df_scoring.columns:
+            df_scoring.loc[df_scoring[poscol].isnull() == False, poscol] = [conv2int(x) for x in df_scoring.loc[df_scoring[poscol].isnull() == False, poscol]]
 
     return(header, df_scoring)
 
@@ -132,13 +130,13 @@ def FixStrandFlips(df):
     df['hm_fixedStrandFlip'] = np.nan
 
     # Correct the effect_allele
-    df['reported_effect_allele'] = np.nan
+    df['hm_reported_effect_allele'] = np.nan
     df.loc[df['hm_code'] == -4, 'hm_reported_effect_allele'] = df.loc[df['hm_code'] == -4, 'effect_allele']
     df.loc[df['hm_code'] == -4, 'effect_allele'] = df.loc[df['hm_code'] == -4, 'effect_allele'].apply(reversecomplement)
 
     # Correct the other_allele
     if 'other_allele' in df.columns:
-        df['reported_other_allele'] = np.nan
+        df['hm_reported_other_allele'] = np.nan
         df.loc[df['hm_code'] == -4, 'hm_reported_other_allele'] = df.loc[df['hm_code'] == -4, 'other_allele']
         df.loc[df['hm_code'] == -4, 'other_allele'] = df.loc[df['hm_code'] == -4, 'other_allele'].apply(reversecomplement)
 

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -15,7 +15,9 @@ remap_header = {
     'LICENSE': 'pgs_license',
     # Harmonization related
     'HmPOS Build': 'HmPOS_build',
-    'HmPOS Date':'HmPOS_date'
+    'HmPOS Date':'HmPOS_date',
+    'HmVCF Reference': 'HmVCF_ref',
+    'HmVCF Date': 'HmVCF_date'
 } # ToDo remove once Scoring File headers are fixed
 
 
@@ -58,14 +60,12 @@ def read_scorefile(loc_scorefile):
 
     df_scoring = pd.read_table(loc_scorefile, float_precision='round_trip', comment='#',
                                dtype = {'chr_position' : 'object',
-                                        'chr_name' : 'str'})
+                                        'chr_name' : 'object'})
 
     # Make sure certain columns maintain specific datatypes
     if 'reference_allele' in df_scoring.columns:
         df_scoring = df_scoring.rename(columns={"reference_allele": "other_allele"})
 
-    if 'chr_name' in df_scoring.columns:
-        df_scoring['chr_name'] = df_scoring['chr_name'].astype('str') # Asssert character in case there are only chr numbers
     if 'hm_chr' in df_scoring.columns:
         df_scoring['hm_chr'] = df_scoring['hm_chr'].astype('str') # Asssert character in case there are only chr numbers
 
@@ -76,36 +76,6 @@ def read_scorefile(loc_scorefile):
 
     return(header, df_scoring)
 
-
-def DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,alleles = [], ):
-    hm_coding = {
-        (True, False, False): 5,
-        (True, True, False): 4,
-        (True, False, True): -4,
-        (False, False, False): -5
-    }
-    hm_code = hm_coding.get((hm_matchesVCF, hm_isPalindromic, hm_isFlipped), -1)
-    if hm_code == 4:
-        if len(alleles) > 1:
-            rc_alleles = [reversecomplement(x) for x in alleles]
-            for A in alleles:
-                if A in rc_alleles:
-                    hm_code = 3
-    return hm_code
-
-
-def FixStrandFlips(df):
-    df['fixedStrandFlip'] = np.nan
-    df.loc[df['hm_code'] == -4, 'effect_allele'] = df.loc[df['hm_code'] == -4, 'effect_allele'].apply(reversecomplement)
-    if 'other_allele' in df_scoring.columns:
-        df.loc[df['hm_code'] == -4, 'other_allele'] = df.loc[df['hm_code'] == -4, 'other_allele'].apply(reversecomplement)
-    df.loc[df['hm_code'] == -4, 'fixedStrandFlip'] = True
-    return df
-
-
-def unmappable2authorreported(df):
-    # ToDo unmappable2authorreported
-    return df
 
 def create_scoringfileheader(h):
     """Function to extract score & publication information for the PGS Catalog Scoring File commented header"""
@@ -134,14 +104,57 @@ def create_scoringfileheader(h):
                   '# HmPOS Build = {}'.format(h['HmPOS_build']),
                   '# HmPOS Date = {}'.format(h['HmPOS_date'])
                   ]
+        if 'HmVCF_ref' in h:
+            lines += ['# HmVCF Reference = {}'.format(h['HmVCF_ref']),
+                      '# HmVCF Date = {}'.format(h['HmVCF_date'])
+                      ]
     return lines
 
+
+def DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,alleles = [], ):
+    hm_coding = {
+        (True, False, False): 5,
+        (True, True, False): 4,
+        (True, False, True): -4,
+        (False, False, False): -5
+    }
+    hm_code = hm_coding.get((hm_matchesVCF, hm_isPalindromic, hm_isFlipped), -1)
+    if hm_code == 4:
+        if len(alleles) > 1:
+            rc_alleles = [reversecomplement(x) for x in alleles]
+            for A in alleles:
+                if A in rc_alleles:
+                    hm_code = 3
+    return hm_code
+
+
+def FixStrandFlips(df):
+    df['hm_fixedStrandFlip'] = np.nan
+
+    # Correct the effect_allele
+    df['reported_effect_allele'] = np.nan
+    df.loc[df['hm_code'] == -4, 'hm_reported_effect_allele'] = df.loc[df['hm_code'] == -4, 'effect_allele']
+    df.loc[df['hm_code'] == -4, 'effect_allele'] = df.loc[df['hm_code'] == -4, 'effect_allele'].apply(reversecomplement)
+
+    # Correct the other_allele
+    if 'other_allele' in df.columns:
+        df['reported_other_allele'] = np.nan
+        df.loc[df['hm_code'] == -4, 'hm_reported_other_allele'] = df.loc[df['hm_code'] == -4, 'other_allele']
+        df.loc[df['hm_code'] == -4, 'other_allele'] = df.loc[df['hm_code'] == -4, 'other_allele'].apply(reversecomplement)
+
+    df.loc[df['hm_code'] == -4, 'hm_fixedStrandFlip'] = True
+    return df
+
+
+def unmappable2authorreported(df):
+    # ToDo unmappable2authorreported
+    return df
 
 
 class Harmonizer:
     """Class to select and harmonize variant locations in a PGS Scoring file."""
-    def __init__(self, cols, ensureOtherAllele=False, returnVariantID = False):
-        '''Used to select the columns and ordering of the output PGS Scoring file'''
+    def __init__(self, cols, returnVariantID=False):
+        """Used to select the columns and ordering of the output PGS Scoring file"""
         self.cols_previous = cols
         self.hm_fields = ['rsID', 'chr_name', 'chr_position', 'effect_allele', 'other_allele']
 
@@ -156,98 +169,99 @@ class Harmonizer:
 
         # Check if there is a reference allele will be added
         self.cols_order.append('effect_allele')
-        if ('other_allele' in self.cols_previous) or (ensureOtherAllele is True):
+        if 'other_allele' in self.cols_previous:
             self.cols_order.append('other_allele')
 
         # Check which other columns need to be added
         for c in self.cols_previous:
-            if c not in self.cols_order:
+            if (c not in self.cols_order) and (c.startswith('hm_') is False):
                 self.cols_order.append(c)
 
         self.cols_order += ['hm_code', 'hm_info']
 
-    def format_line(self, v, hm, hm_source, build, rsid=None,vcfid=None, fixflips=True, unmappable2authorreported=False):
+    def format_line(self, v, original_build):
         """Method that takes harmonized variant location and compares it with the old information.
         Outputs any changes to an hm_info dictionary"""
-        if type(hm) == tuple:
-            hm = list(hm)
-        v = dict(v)
-        v['variant_id'] = vcfid
+        # Initialize Output
+        l_output = ['']*len(self.cols_order)
+        hm_info = {}
 
-        if (unmappable2authorreported is True) and (hm[2] == -5):
-            hm[2] = 0 # If the variant does not work revert to author-reported if possible
+        # Decide how to output the variant (pass/fail harmonization)
+        PassHM = True
+        hm_code = v['hm_code']
+        if hm_code is None:
+            v['hm_code'] = -1
+        if hm_code < 0: #Proceed as if it's not mapped
+            PassHM = False
+            if hm_code == -4:
+                if 'hm_fixedStrandFlip' in v:
+                    if v['hm_fixedStrandFlip'] is True:
+                        hm_info['fixedStrandFlip'] = True
+                        hm_info['reported_effect_allele'] = v['hm_reported_effect_allele']
+                        if 'reported_other_allele' in v:
+                            hm_info['reported_other_allele'] = v['hm_reported_other_allele']
+                        PassHM = True
+                    else:
+                        hm_info['fixedStrandFlip'] = False
 
-        hm_info = {'hm_source' : hm_source}
-        if (hm[2] is None) or (hm[2] < 0):
-            if hm[2] is None:
-                v['hm_code'] = -1 # Unable to map the variant
-            else:
-                v['hm_code'] = hm[2] # Variant does not match ENSEMBL Variation
+        # Create Output
+        l_output[self.cols_order.index('hm_code')] = hm_code
 
-            if (v['hm_code'] == -4) and (fixflips is True):
-                hm_info['original_build'] = build
-                hm_info['fixedStrandFlip'] = True
-                for c in self.hm_fields:
-                    f = v.get(c)
-                    if f is not None:
-                        if c in ['effect_allele', 'other_allele']:
-                            flipped_allele = reversecomplement(f)
-                            hm_info['original_{}'.format(c)] = f
-                            v[c] = flipped_allele
-                        elif c == 'rsID':
-                            if rsid is not None:  # mapped by rsID
-                                if rsid != v['rsID']:
-                                    hm_info['previous_rsID'] = v['rsID']
-                                    v['rsID'] = rsid
-                        else:
-                            hm_info[c] = f
-                            v[c] = ''
-                v['chr_name'] = hm[0]
-                v['chr_position'] = hm[1]
-            else:
-                if (v['hm_code'] == -4) and (fixflips is False):
-                    hm_info['fixedStrandFlip'] = False
-                # Fill in the original mapping in 'hm_info' and remove the harmonized variant information from the column
-                hm_info['original_build'] = build
-                for c in self.hm_fields:
-                    f = v.get(c)
-                    if f:
-                        hm_info[c] = f
-                        v[c] = ''
-                if ('variant_id' in self.cols_order) and (vcfid is not None):
-                    hm_info['variant_id'] = vcfid
-                    v['variant_id'] = ''
-
-                # If the variant was lifted but the allele's don't match add the lifted over positions
-                if hm[0] is not None:
-                    hm_info['hm_chr'] = hm[0]
-                if hm[1] is not None:
-                    hm_info['hm_chr_position'] = hm[1]
+        if original_build is None:
+            original_build = 'NR'
+        if PassHM is True:
+            for i, colname in enumerate(self.cols_order):
+                if colname == 'chr_name':
+                    l_output[i] = v['hm_chr']
+                elif colname == 'chr_position':
+                    l_output[i] = v['hm_pos']
+                elif colname == 'rsID':
+                    rsid = v['hm_rsID']
+                    if pd.isnull(rsid) is False:  # mapped by rsID
+                        l_output[i] = rsid
+                        if rsid != v['rsID']:
+                            hm_info['previous_rsID'] = v['rsID']
+                    else:
+                        l_output[i] = v['rsID']
+                elif colname == 'variant_id':
+                    l_output[i] = v['hm_vid']
+                elif colname == 'hm_code':
+                    l_output[i] = hm_code
+                elif colname == 'hm_info':
+                    if len(hm_info) > 0:
+                        l_output[i] = json.dumps(hm_info)
+                else:
+                    l_output[i] = v[colname]
         else:
-            v['chr_name'] = hm[0]
-            v['chr_position'] = hm[1]
-            v['hm_code'] = hm[2]
-            if rsid is not None: # mapped by rsID
+            hm_info['reported_build'] = original_build
+            if pd.isnull(v['hm_chr']) is False:
+                hm_info['hm_chr'] = v['hm_chr']
+            if pd.isnull(v['hm_pos']) is False:
+                hm_info['hm_pos'] = v['hm_pos']
+            rsid = v['hm_rsID']
+            if pd.isnull(rsid) is False:  # mapped by rsID
+                hm_info['rsID'] = rsid
                 if rsid != v['rsID']:
                     hm_info['previous_rsID'] = v['rsID']
-                    v['rsID'] = rsid
-
-        # Create output
-        o = []
-        for c in self.cols_order:
-            if c == 'hm_info':
-                if len(hm_info) > 0:
-                    o.append(json.dumps(hm_info))
-                else:
-                    o.append('')
-            elif c in v:
-                val = str(v[c]).replace('None', '')
-                if val == 'nan':
-                    val = ''
-                o.append(val)
             else:
-                o.append('')
-        return o
+                hm_info['rsID'] = v['rsID']
+
+            for colname in self.hm_fields:
+                if colname in v:
+                    val = v[colname]
+                    if pd.isnull(val) is False:
+                        hm_info[colname] = val
+
+            for i, colname in enumerate(self.cols_order):
+                if colname not in self.hm_fields:
+                    if colname == 'variant_id':
+                        hm_info['variant_id'] = v['hm_vid']
+                    elif colname == 'hm_info':
+                        l_output[i] = json.dumps(hm_info)
+                    else:
+                        l_output[i] = v[colname]
+
+        return pd.Series(l_output)
 
 
 

--- a/pgs_harmonizer/variantlookup_tools.py
+++ b/pgs_harmonizer/variantlookup_tools.py
@@ -165,7 +165,7 @@ def vcf_lookup(chromosome, position, build, loc_vcfref='map/vcf_ref/'):
 
 class VCFs:
     """Class to open and hold all VCF files for a genome build"""
-    def __init__(self, build, loc_vcfref='map/vcf_ref/', cohort_name=None, loc_cohortref='map/cohort_ref/'):
+    def __init__(self, build, loc_vcfref='map/vcf_ref/', cohort_name=None):
         self.VCF = None
         self.by_chr = {}
         self.build = build
@@ -174,8 +174,9 @@ class VCFs:
                 loc_vcf = loc_vcfref + '{}/homo_sapiens-chr{}.vcf.gz'.format(self.build, chr)
                 self.by_chr[chr] = VCF(loc_vcf)
         else:
-            loc_vcf = '{}/{}.vcf.gz'.format(loc_cohortref, cohort_name)
-            self.VCF = VCF(loc_vcf)
+            loc_vcf = '{}/{}/cohort_ref/{}.vcf.gz'.format(loc_vcfref, build, cohort_name)
+            if os.path.isfile(loc_vcf):
+                self.VCF = VCF(loc_vcf)
 
     def vcf_lookup(self,chromosome, position, rsid = None):
         """Lookup a variant in a specific genome build"""
@@ -200,17 +201,5 @@ class VCFs:
 
         return VCFResult(chromosome, position, self.build, r_lookup)
 
-
-class CohortVariants:
-    """Class to load cohort-specific variants information and compare alleles"""
-    def __init__(self, cohortname, variants_table):
-        self.cohort = cohortname
-        self.variants_table = variants_table
-
-    def check_variant(self):
-        """Checks whether the variant (chr, pos, alleles) is genotyped/imputed in this cohort"""
-
-    def infer_reference_allele(self, chr, pos, eff, rsID = None):
-        """Try to infer the reference_allele based on genotyped/imputed variants in this cohort"""
 
 #def guess_build(loc_file, vcf_root):

--- a/pgs_harmonizer/variantlookup_tools.py
+++ b/pgs_harmonizer/variantlookup_tools.py
@@ -202,4 +202,4 @@ class VCFs:
         return VCFResult(chromosome, position, self.build, r_lookup)
 
 
-#def guess_build(loc_file, vcf_root):
+# def guess_build(loc_file, vcf_root):


### PR DESCRIPTION
- Only have to get harmonised positions once (HmPOS)
- Faster to run on multiple cohorts/VCF references
- Slightly less memory requirements (splits by chromosome or by 100,000 variant chunks)