### PR TITLE
Consistent columns + handling of duplicates

### DIFF
--- a/Harmonize.py
+++ b/Harmonize.py
@@ -64,7 +64,7 @@ parser_VCF.add_argument('--addOtherAllele',
                         help='Adds a other_allele(s) column for PGS that only have a recorded effect_allele',
                         action='store_true', required=False)
 parser_VCF.add_argument('--addVariantID',
-                        help='Returns a column with the ID from the VCF corresponding to the match variant/allele(s)',
+                        help='Returns a column with the ID from the VCF corresponding to the matched variant/allele(s)',
                         action='store_true', required=False)
 parser_VCF.add_argument('--author_reported',
                         help='Replaces unmappable variants (hm_code = -5) with the author-reported code (hm_code = 0)',

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ optional arguments:
   --split_unmappable  This flag will write unmapped & uncorrected variants
                       (hm_code < 0) to separate files (suffixes: [.mapped,
                       .unmatched])
+  --keep_duplicates   This flag will allows duplicate variants to be present
+                      in the mapped variant file. The default behaviour is to
+                      drop them.
   --gzip              Writes gzipped harmonized output
   --silent_tqdm       Disables tqdm progress bar
-(pgs-harmonizer) cmpc373:pgs-harmonizer sl925$ 
-
 </pre>
 
 ## Examples
@@ -138,6 +139,7 @@ ENDFOR
      |    |         ambiguous orientations exist at the locus]           |
      | 3  | Mapped [variant in REFERENCE VCF with ambiguous orientation  |
      |    |         (e.g. A/T, C/G variants) ]                           |
+     | 1  | Duplicated harmonized variant (multiple lines map to 1 ID    |
      | 0  | Author-reported variant information (not found in VCF)       |
      |-1  | Unable to map the variant                                    |
      |-4  | Strands flipped? [reverse complement alleles exist in VCF,   |

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ optional arguments:
                       otherwise assumed to be in: PGS_HmPOS/
   -loc_hmoutput DIR   Directory where the harmonization output will be saved
                       (default: PGS_HmPOS/)
-  -loc_vcfs DIR       Directory where the VCF files are located
-                      (default: map/vcf_ref)
+  -loc_vcfs DIR       Directory where the VCF files are located, otherwise
+                      assumed to be in: map/vcf_ref/
   -cohort_vcf COHORT  Cohort VCF: Used to check if a variant is present in the
                       genotyped/imputed variants for a cohort and add other
                       allele when the information from ENSEMBL is ambiguous
@@ -81,13 +81,16 @@ optional arguments:
   --addOtherAllele    Adds a other_allele(s) column for PGS that only have a
                       recorded effect_allele
   --addVariantID      Returns a column with the ID from the VCF corresponding
-                      to the match variant/allele(s)
-  --author_reported   Replaces unmappable variants (hm_code = -5) with the
-                      author-reported code (hm_code = 0)
-  --skip_strandflips  This flag will stop the harmonizing from trying to
-                      correct strand flips
-  --silent_tqdm       Disables tqdm progress bar
+                      to the matched variant/allele(s)
+  --skip_strandflips  This flag will stop the harmonizer from correcting
+                      strand flips
+  --split_unmappable  This flag will write unmapped & uncorrected variants
+                      (hm_code < 0) to separate files (suffixes: [.mapped,
+                      .unmatched])
   --gzip              Writes gzipped harmonized output
+  --silent_tqdm       Disables tqdm progress bar
+(pgs-harmonizer) cmpc373:pgs-harmonizer sl925$ 
+
 </pre>
 
 ## Examples

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -78,7 +78,7 @@ def read_scorefile(loc_scorefile):
     return(header, df_scoring)
 
 
-def create_scoringfileheader(h):
+def create_scoringfileheader(h, skipfields=[]):
     """Function to extract score & publication information for the PGS Catalog Scoring File commented header"""
     # Recreate original header
     lines = [
@@ -109,10 +109,16 @@ def create_scoringfileheader(h):
             lines += ['# HmVCF Reference = {}'.format(h['HmVCF_ref']),
                       '# HmVCF Date = {}'.format(h['HmVCF_date'])
                       ]
+            # N Matched Variants
+            if ('HmVCF_n_matched' in h) and ('HmVCF_n_matched' not in skipfields):
+                lines.append('# HmVCF N Matched Variants = {}'.format(h['HmVCF_n_matched']))
+            # N Unmatched Variants
+            if ('HmVCF_n_unmapped' in h) and ('HmVCF_n_unmapped' not in skipfields):
+                lines.append('# HmVCF N Unmapped Variants = {}'.format(h['HmVCF_n_unmapped']))
     return lines
 
 
-def DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,alleles = [], ):
+def DetermineHarmonizationCode(hm_matchesVCF, hm_isPalindromic, hm_isFlipped,alleles = []):
     hm_coding = {
         (True, False, False): 5,
         (True, True, False): 4,

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -147,9 +147,9 @@ def FixStrandFlips(df):
     return df
 
 
-def unmappable2authorreported(df):
-    # ToDo unmappable2authorreported
-    return df
+# def unmappable2authorreported(df):
+#     # ToDo unmappable2authorreported
+#     return df
 
 
 class Harmonizer:
@@ -163,7 +163,7 @@ class Harmonizer:
         if 'rsID' in cols:
             self.has_rsID = True
 
-        self.variant_id_vcf = returnVariantID  #  # return the variant_id from the VCF file or rsID as default
+        self.variant_id_vcf = returnVariantID  # return the variant_id from the VCF file or rsID as default
 
         # Standard set of columns (vaguely like VCF)
         self.cols_order = ['chr_name', 'chr_position', 'variant_id',
@@ -225,7 +225,8 @@ class Harmonizer:
             # MANDATORY: variant_id
             if self.variant_id_vcf is True:
                 l_output[self.cols_order.index('variant_id')] = v['hm_vid']  # Return the ID from VCF
-            elif self.has_rsID:
+
+            if self.has_rsID:
                 rsID = v['hm_rsID']
                 old_rsID = v['rsID']
                 if pd.isnull(rsID) is False:
@@ -236,7 +237,7 @@ class Harmonizer:
                         l_output[self.cols_order.index('variant_id')] = rsID
                     else:
                         hm_info['rsID'] = rsID  # Write to hm_info for provenance
-            else:
+            if l_output[self.cols_order.index('variant_id')] == '':
                 l_output[self.cols_order.index('variant_id')] = missing_val  # Return missing val
 
             # MANDATORY: hm_info
@@ -267,10 +268,13 @@ class Harmonizer:
                     if pd.isnull(v['hm_pos']) is False:
                         hm_info['hm_pos'] = v['hm_pos']
                 elif colname == 'variant_id':
-                    hm_info['variant_id'] = v['hm_vid']
+                    if pd.isnull(v['hm_vid']) is False:
+                        hm_info['variant_id'] = v['hm_vid']
                     l_output[i] = missing_val
                 elif colname in ['effect_allele', 'other_allele']:
-                    hm_info[colname] = v[colname]
+                    val = v[colname]
+                    if pd.isnull(val) is False:
+                        hm_info[colname] = val
                 elif colname == 'hm_info':
                     l_output[i] = json.dumps(hm_info)
                 elif colname == 'hm_code':

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -17,7 +17,9 @@ remap_header = {
     'HmPOS Build': 'HmPOS_build',
     'HmPOS Date':'HmPOS_date',
     'HmVCF Reference': 'HmVCF_ref',
-    'HmVCF Date': 'HmVCF_date'
+    'HmVCF Date': 'HmVCF_date',
+    'HmVCF N Matched Variants': 'HmVCF_n_matched',
+    'HmVCF N Unmapped Variants': 'HmVCF_n_unmapped'
 } # ToDo remove once Scoring File headers are fixed
 
 


### PR DESCRIPTION
- Consistent column order and number: `['chr_name', 'chr_position', 'variant_id', 'effect_allele', 'other_allele', 'effect_weight','hm_code', 'hm_info']`
- This includes functionality to optionally return the VCF's variant ID, the original rsID, or return a missing value '.'
- Splits matched and unmapped variants into separate files (updates to README to reflect this)
