### PR TITLE
Compares rsID-derived and author-reported positions

### DIFF
--- a/DownloadMappings.py
+++ b/DownloadMappings.py
@@ -1,19 +1,42 @@
+import argparse
 import os
 import ftplib
 
-# Check/create structure to hold VCF files
-if os.path.isdir('map/') is False:
-    os.mkdir('map/')
-if os.path.isdir('map/vcf_ref/') is False:
-    os.mkdir('map/vcf_ref/')
 
-vcf_builds = ['GRCh37', 'GRCh38']
-vcf_chrs = list(range(1,23)) + ['X', 'Y', 'MT']
+vcf_chrs = [str(x) for x in range(1,23)] + ['X', 'Y', 'MT']
+
+parser = argparse.ArgumentParser(
+    description='Download VCFs from ENSEMBL.')
+parser.add_argument(dest="genome_build",
+                    help="Target genome build choices: GRCh37, GRCh38, or both (GRCh3*)", metavar="GRCh3#",
+                    choices=['GRCh37', 'GRCh38', 'GRCh3*'])
+parser.add_argument(dest="loc_outputs",
+                    help="Directory where the VCF files will be saved (default: PGS_HmPOS/)",
+                    metavar="OUTDIR")
+parser.add_argument('-chrom', dest='single_chrom',
+                    help='Option to download a single chrom, otherwise all chromosomes will be downloaded',
+                    metavar="CHR", choices=vcf_chrs, required=False)
+args = parser.parse_args()
+
+# Check/create structure to hold VCF files
+if os.path.isdir(args.loc_outputs) is False:
+    os.mkdir(args.loc_outputs)
+
+if args.genome_build == 'GRCh3*':
+    vcf_builds = ['GRCh37', 'GRCh38']
+else:
+    vcf_builds = [args.genome_build]
 
 for build in vcf_builds:
     if os.path.isdir('map/vcf_ref/{}'.format(build)) is False:
         os.mkdir('map/vcf_ref/{}'.format(build))
         os.mkdir('map/vcf_ref/{}/cohort_ref'.format(build))
+
+# Check which chromosomes to download
+if args.single_chrom is not None:
+    dl_chrs = [args.single_chrom]
+else:
+    dl_chrs = vcf_chrs
 
 # Download VCF files from ENSEMBL FTP
 ensembl_ftp = ftplib.FTP("ftp.ensembl.org")
@@ -24,7 +47,7 @@ for build in vcf_builds:
     if build == 'GRCh37':
         vcf_loc = 'pub/grch37/current/variation/vcf/homo_sapiens/'
 
-    for chr in vcf_chrs:
+    for chr in dl_chrs:
         print('Downloading (vcf):', build, 'chr{}'.format(chr))
         try:
             # Download vcf

--- a/Harmonize.py
+++ b/Harmonize.py
@@ -261,9 +261,9 @@ def run_HmPOS(args, chunksize=100000):
     if isSameBuild:
         hm_matches = {}
         if 'chr_name' in df_scoring.columns:
-            hm_matches['chr_name'] = {}
+            hm_matches['chr_name'] = {True: 0, False: 0}
         if 'chr_position' in df_scoring.columns:
-            hm_matches['chr_position'] = {}
+            hm_matches['chr_position'] = {True: 0, False: 0}
     else:
         hm_matches = None
 
@@ -288,8 +288,7 @@ def run_HmPOS(args, chunksize=100000):
                     if 'chr_name' in df_scoring.columns:
                         df_chunk['hm_match_chr'] = np.nan
                         i_chr_notnull = (df_chunk['chr_name'].isnull() == False)
-                        df_chunk.loc[i_chr_notnull & (df_chunk['chr_name'] == df_chunk['hm_chr']), 'hm_match_chr'] = True
-                        df_chunk.loc[i_chr_notnull & (df_chunk['chr_name'] != df_chunk['hm_chr']), 'hm_match_chr'] = False
+                        df_chunk.loc[i_chr_notnull, 'hm_match_chr'] = (df_chunk.loc[i_chr_notnull, 'chr_name'] == df_chunk.loc[i_chr_notnull, 'hm_chr'])
 
                         for hm_source, hm_count in dict(df_chunk['hm_match_chr'].value_counts()).items():
                             if hm_source in hm_matches['chr_name']:
@@ -299,8 +298,7 @@ def run_HmPOS(args, chunksize=100000):
                     if 'chr_position' in df_scoring.columns:
                         df_chunk['hm_match_pos'] = np.nan
                         i_pos_notnull = (df_chunk['chr_position'].isnull() == False)
-                        df_chunk.loc[i_pos_notnull & (df_chunk['chr_position'] == df_chunk['hm_pos']), 'hm_match_pos'] = True
-                        df_chunk.loc[i_pos_notnull & (df_chunk['chr_position'] != df_chunk['hm_pos']), 'hm_match_pos'] = False
+                        df_chunk.loc[i_pos_notnull, 'hm_match_pos'] = (df_chunk.loc[i_pos_notnull, 'chr_position'] == df_chunk.loc[i_pos_notnull, 'hm_pos'])
                         for hm_source, hm_count in dict(df_chunk['hm_match_pos'].value_counts()).items():
                             if hm_source in hm_matches['chr_name']:
                                 hm_matches['chr_position'][hm_source] += hm_count
@@ -327,7 +325,7 @@ def run_HmPOS(args, chunksize=100000):
         print('Mapped {} -> {}'.format(header['pgs_id'], loc_hm_out))
         print('Variant Sources: {}'.format(hm_counts))
         if hm_matches:
-            print('Summary of Annotation Matches: {}'.format(hm_matches))
+            print('Comparison of rsID vs. author-reported positions: {}'.format(hm_matches))
         return
     else:
         hm_out.close()

--- a/pgs_harmonizer/harmonize.py
+++ b/pgs_harmonizer/harmonize.py
@@ -183,6 +183,10 @@ class Harmonizer:
         self.cols_order = ['chr_name', 'chr_position', 'variant_id',
                            'effect_allele', 'other_allele', 'effect_weight',
                            'hm_code', 'hm_info']
+        if 'hm_match_chr' in self.cols_previous:
+            self.cols_order.append('hm_match_chr')
+        if 'hm_match_pos' in self.cols_previous:
+            self.cols_order.append('hm_match_pos')
         self.cols_extra = []
 
         # Check which other columns need to be added


### PR DESCRIPTION
Can be used after HmPOS to try and identify when the original scoring has positions in the wrong reported build (e.g. inconsistent with the rsIDs). 